### PR TITLE
opt: fix move ctor, move assign and emplace

### DIFF
--- a/test/opt.cpp
+++ b/test/opt.cpp
@@ -1,6 +1,26 @@
 
 #include "test.h"
 
+struct InstCnt {
+    InstCnt() {
+        ++cnt;
+    }
+    ~InstCnt() {
+        --cnt;
+    }
+    InstCnt(const InstCnt&) {
+        ++cnt;
+    }
+    InstCnt(InstCnt&&) {
+        ++cnt;
+    }
+    InstCnt& operator=(const InstCnt&) = delete;
+    InstCnt& operator=(InstCnt&&) = delete;
+
+    static i32 cnt;
+};
+i32 InstCnt::cnt = 0;
+
 i32 main() {
     Test test{"empty"_v};
     Trace("Storage") {
@@ -42,5 +62,53 @@ i32 main() {
 
         Opt<Thread::Mutex> m;
     }
+    Trace("OptInstCnt") {
+        Opt<InstCnt> c1;
+        assert(InstCnt::cnt == 0);
+
+        // Move assign value type.
+        c1 = InstCnt{};
+        assert(InstCnt::cnt == 1);
+        c1 = InstCnt{};
+        assert(InstCnt::cnt == 1);
+        c1.clear();
+        assert(InstCnt::cnt == 0);
+
+        // Emplace value type.
+        c1.emplace();
+        assert(InstCnt::cnt == 1);
+        c1.emplace();
+        assert(InstCnt::cnt == 1);
+        c1.clear();
+        assert(InstCnt::cnt == 0);
+
+        // Move construct from value type.
+        Opt<InstCnt> c2(InstCnt{});
+        assert(InstCnt::cnt == 1);
+
+        // Move construct from Opt type, moves inner value.
+        c1 = rpp::move(c2);
+        assert(InstCnt::cnt == 2);
+        c2.clear();
+        assert(InstCnt::cnt == 1);
+        c1.clear();
+        assert(InstCnt::cnt == 0);
+
+        // Move construct from Opt type.
+        c1.emplace();
+        Opt<InstCnt> c3(rpp::move(c1));
+        assert(InstCnt::cnt == 2);
+
+        c1.clear();
+        assert(InstCnt::cnt == 1);
+        c3.clear();
+        assert(InstCnt::cnt == 0);
+
+        // Clone and move assign Opt type.
+        c1.emplace();
+        c2 = c1.clone();
+        assert(InstCnt::cnt == 2);
+    }
+    assert(InstCnt::cnt == 0);
     return 0;
 }


### PR DESCRIPTION
Here is an initial version, attempting to fix #4.

* fix move ctor, move assign and emplace
* move all destruction logic into Opt<T>::clear().
* add Opt unittest counting object instances.