### PR TITLE
fix crashes during destruction of static objects

### DIFF
--- a/rpp/impl/log.cpp
+++ b/rpp/impl/log.cpp
@@ -40,8 +40,18 @@ struct Static_Data {
     }
 };
 
-static Static_Data g_log_data;
+static char g_log_data_[sizeof(Static_Data)];
+static Static_Data& g_log_data = *(Static_Data*)g_log_data_;
 static thread_local u64 g_log_indent = 0;
+
+detail::StaticInitializer::StaticInitializer() noexcept
+{
+	new(g_log_data_) Static_Data();
+}
+detail::StaticInitializer::~StaticInitializer() noexcept
+{
+	g_log_data.~Static_Data();
+}
 
 #ifdef RPP_OS_WINDOWS
 

--- a/rpp/impl/log.cpp
+++ b/rpp/impl/log.cpp
@@ -40,7 +40,7 @@ struct Static_Data {
     }
 };
 
-static char g_log_data_[sizeof(Static_Data)];
+alignas(Static_Data) static char g_log_data_[sizeof(Static_Data)];
 static Static_Data& g_log_data = *(Static_Data*)g_log_data_;
 static thread_local u64 g_log_indent = 0;
 

--- a/rpp/impl/profile.cpp
+++ b/rpp/impl/profile.cpp
@@ -159,6 +159,8 @@ void Profile::Frame_Profile::exit() noexcept {
 
 void Profile::alloc(Alloc a) noexcept {
     if constexpr(DO_PROFILE) {
+        bool replaced = false;
+        bool no_entry = false;
         {
             Thread::Lock lock(allocs_lock);
             Alloc_Profile& prof = allocs.get_or_insert(a.name);
@@ -166,7 +168,7 @@ void Profile::alloc(Alloc a) noexcept {
             if(a.size) {
 
                 if(prof.current_set.contains(a.address)) {
-                    warn("Profile: % reallocated %!", a.name, a.address);
+                    replaced = true;
                 }
                 prof.current_set.insert(a.address, a.size);
 
@@ -179,7 +181,7 @@ void Profile::alloc(Alloc a) noexcept {
 
                 Opt<Ref<u64>> sz = prof.current_set.try_get(a.address);
                 if(!sz.ok()) {
-                    warn("Profile: % freed % with no entry!", a.name, a.address);
+                    no_entry = true;
                 } else {
                     i64 size = **sz;
                     prof.current_set.erase(a.address);
@@ -189,6 +191,10 @@ void Profile::alloc(Alloc a) noexcept {
                 }
             }
         }
+
+        if(replaced) warn("Profile: % reallocated %!", a.name, a.address);
+        if(no_entry) warn("Profile: % freed % with no entry!", a.name, a.address);
+
         {
             if(!this_thread_destroyed) {
                 Thread::Lock lock(this_thread.frames_lock);
@@ -249,10 +255,6 @@ void Profile::finalize() noexcept {
         warn("Unbalanced regions: %", Region_Allocator::depth());
     } else {
         info("No regions leaked.");
-    }
-    if(net != 0) {
-        warn("Memory leaked, shutting down now...");
-        Libc::exit(1);
     }
 }
 

--- a/rpp/impl/profile.cpp
+++ b/rpp/impl/profile.cpp
@@ -190,9 +190,11 @@ void Profile::alloc(Alloc a) noexcept {
             }
         }
         {
-            Thread::Lock lock(this_thread.frames_lock);
-            if(this_thread.during_frame) {
-                this_thread.frames.back().allocations.push(rpp::move(a));
+            if(!this_thread_destroyed) {
+                Thread::Lock lock(this_thread.frames_lock);
+                if(this_thread.during_frame) {
+                    this_thread.frames.back().allocations.push(rpp::move(a));
+                }
             }
         }
     }

--- a/rpp/log.h
+++ b/rpp/log.h
@@ -92,6 +92,13 @@ void log(Level level, const Location& loc, String_View fmt, const Ts&... args) n
     Region(R) output(level, loc, format<Mregion<R>>(fmt, args...).view());
 }
 
+namespace detail {
+struct StaticInitializer {
+    StaticInitializer() noexcept;
+    ~StaticInitializer() noexcept;
+} inline static_initializer;
+}; // namespace detail
+
 } // namespace Log
 
 RPP_NAMED_ENUM(Log::Level, "Level", info, RPP_CASE(info), RPP_CASE(warn), RPP_CASE(fatal));

--- a/rpp/log.h
+++ b/rpp/log.h
@@ -93,10 +93,15 @@ void log(Level level, const Location& loc, String_View fmt, const Ts&... args) n
 }
 
 namespace detail {
-struct StaticInitializer {
-    StaticInitializer() noexcept;
-    ~StaticInitializer() noexcept;
-} inline static_initializer;
+
+struct Static_Init {
+    Static_Init() noexcept;
+    ~Static_Init() noexcept;
+};
+
+// Constructed before subsequent globals and destructed after them.
+inline Static_Init g_initializer;
+
 }; // namespace detail
 
 } // namespace Log

--- a/rpp/profile.h
+++ b/rpp/profile.h
@@ -138,6 +138,7 @@ private:
         }
         ~Thread_Profile() noexcept {
             finalize();
+            this_thread_destroyed = true;
         }
 
         void finalize() noexcept {
@@ -161,6 +162,7 @@ private:
     static inline Thread::Mutex allocs_lock;
     static inline Thread::Mutex finalizers_lock;
     static inline thread_local Thread_Profile this_thread;
+    static inline thread_local bool this_thread_destroyed = false;
     static inline Map<Thread::Id, Ref<Thread_Profile>, Mhidden> threads;
     static inline Map<String_View, Alloc_Profile, Mhidden> allocs;
     static inline Vec<Function<void()>, Mhidden> finalizers;

--- a/test/static.cpp
+++ b/test/static.cpp
@@ -1,0 +1,49 @@
+
+#include "test.h"
+
+#include <rpp/base.h>
+#include <rpp/thread.h>
+
+using Alloc = Mallocator<"Alloc">;
+
+// Creates two unbalanced allocations, since Profile::finalize occurs before it is destroyed.
+Test test{"static"_v};
+
+struct Destroy {
+    ~Destroy() {
+        info("Logged at static destruction.");
+        Profile::finalize();
+    }
+};
+Destroy at_exit;
+
+Vec<i32, Alloc> g_vec0;
+Vec<i32, Alloc> g_vec1{1, 2, 3};
+
+i32 main() {
+    Profile::begin_frame();
+
+    static Vec<i32, Alloc> vec{1, 2, 3};
+    static Box<i32, Alloc> box{5};
+
+    static thread_local Vec<i32, Alloc> tls_vec{1, 2, 3};
+    static thread_local Box<i32, Alloc> tls_box{5};
+
+    info("g_vec0: %", g_vec0);
+    info("g_vec1: %", g_vec1);
+    info("vec: %", vec);
+    info("box: %", box);
+    info("tls_vec: %", tls_vec);
+    info("tls_box: %", tls_box);
+
+    auto v = Thread::spawn([]() {
+        tls_vec = Vec<i32, Alloc>{1, 2, 3, 4, 5};
+        info("tls_vec in thread: %", tls_vec);
+        info("tls_box in thread: %", tls_box);
+        return move(tls_vec);
+    });
+    info("Thread returned: %", v->block());
+
+    Profile::end_frame();
+    return 0;
+}

--- a/test/static.cpp
+++ b/test/static.cpp
@@ -6,16 +6,15 @@
 
 using Alloc = Mallocator<"Alloc">;
 
-// Creates two unbalanced allocations, since Profile::finalize occurs before it is destroyed.
-Test test{"static"_v};
-
 struct Destroy {
     ~Destroy() {
-        info("Logged at static destruction.");
+        info("Log at static destruction.");
         Profile::finalize();
     }
 };
 Destroy at_exit;
+
+Test test{"static"_v};
 
 Vec<i32, Alloc> g_vec0;
 Vec<i32, Alloc> g_vec1{1, 2, 3};

--- a/test/static.expect
+++ b/test/static.expect
@@ -7,19 +7,3 @@
 [Level::info] tls_vec in thread: Vec[1, 2, 3, 4, 5]
 [Level::info] tls_box in thread: Box{null}
 [Level::info] Thread returned: Vec[1, 2, 3, 4, 5]
-[Level::info] Logged at static destruction.
-[Level::info] Allocation stats for [Alloc]:
-[Level::info] 	Allocs: 6
-[Level::info] 	Frees: 6
-[Level::info] 	High water: 64
-[Level::info] 	Alloc size: 64
-[Level::info] 	Free size: 64
-[Level::info] Allocation stats for [Threading]:
-[Level::info] 	Allocs: 2
-[Level::info] 	Frees: 2
-[Level::info] 	High water: 56
-[Level::info] 	Alloc size: 56
-[Level::info] 	Free size: 56
-[Level::warn] Unbalanced allocations: 2
-[Level::info] No region memory leaked.
-[Level::info] No regions leaked.

--- a/test/static.expect
+++ b/test/static.expect
@@ -1,0 +1,25 @@
+[Level::info] g_vec0: Vec[]
+[Level::info] g_vec1: Vec[1, 2, 3]
+[Level::info] vec: Vec[1, 2, 3]
+[Level::info] box: Box{5}
+[Level::info] tls_vec: Vec[1, 2, 3]
+[Level::info] tls_box: Box{5}
+[Level::info] tls_vec in thread: Vec[1, 2, 3, 4, 5]
+[Level::info] tls_box in thread: Box{null}
+[Level::info] Thread returned: Vec[1, 2, 3, 4, 5]
+[Level::info] Logged at static destruction.
+[Level::info] Allocation stats for [Alloc]:
+[Level::info] 	Allocs: 6
+[Level::info] 	Frees: 6
+[Level::info] 	High water: 64
+[Level::info] 	Alloc size: 64
+[Level::info] 	Free size: 64
+[Level::info] Allocation stats for [Threading]:
+[Level::info] 	Allocs: 2
+[Level::info] 	Frees: 2
+[Level::info] 	High water: 56
+[Level::info] 	Alloc size: 56
+[Level::info] 	Free size: 56
+[Level::warn] Unbalanced allocations: 2
+[Level::info] No region memory leaked.
+[Level::info] No regions leaked.

--- a/test/test.h
+++ b/test/test.h
@@ -6,12 +6,10 @@
 using namespace rpp;
 
 struct Test {
-    using Alloc = Mallocator<"Test">;
-
     explicit Test(String_View name) : name(name) {
         token = Log::subscribe(
             [&](Log::Level lvl, Thread::Id, Log::Time, Log::Location, String_View msg) {
-                auto m = format<Alloc>("[%] %\n"_v, lvl, msg);
+                auto m = format<Mhidden>("[%] %\n"_v, lvl, msg);
                 for(u8 c : m) {
                     result.push(c);
                 }
@@ -20,7 +18,7 @@ struct Test {
     ~Test() {
         Log::unsubscribe(token);
 
-        auto expect = name.append<Alloc>(".expect"_v);
+        auto expect = name.append<Mdefault>(".expect"_v);
         expected = move(*Files::read(expect.view()));
 
         bool differs = false;
@@ -36,14 +34,14 @@ struct Test {
         }
 
         if(differs) {
-            auto corrected = name.append<Alloc>(".corrected"_v);
+            auto corrected = name.append<Mdefault>(".corrected"_v);
             static_cast<void>(Files::write(corrected.view(), result.slice()));
             Libc::exit(1);
         }
     }
 
     String_View name;
-    Vec<u8, Alloc> result;
+    Vec<u8, Mhidden> result;
     Vec<u8, Files::Alloc> expected;
     Log::Token token;
 };


### PR DESCRIPTION
Fixes #7.

`this_thread` is defined here with thread storage duration
https://github.com/TheNumbat/rpp/blob/29ad6ef08d82658b4aefc46efcb2e5455d63f1c9/rpp/profile.h#L163
and used here, in a place ultimately reached by the destructor with the default allocator (`Mallocator` with `Log == true`).
https://github.com/TheNumbat/rpp/blob/29ad6ef08d82658b4aefc46efcb2e5455d63f1c9/rpp/impl/profile.cpp#L193-L196
From [[basic.start.term]](https://open-std.org/jtc1/sc22/wg21/docs/papers/2023/n4950.pdf#subsubsection.6.9.3.4),
> 2. Constructed objects with thread storage duration within a given thread are destroyed as a result of returning from the initial function of that thread and as a result of that thread calling std::exit. The destruction of all constructed objects with thread storage duration within that thread strongly happens before destroying any object with static storage duration.

we know that the destructor for `this_thread` will be called before those of any objects of static storage duration. This explains the error message seen in #7 example 1, as after calling the destructor of `Vec` the snippet above is trying to lock a mutex that has already been destroyed. Since `Thead_Profile` has a non-trivial destructor, it is undefined behaviour to use it after destruction and I therefore added a boolean flag to track whether or not its destructor has been called, and to avoid using the object if it has. This should prevent crashes but will not allow for complete allocation tracking. A workaround might be to move the `Thread_Profile` out of TLS and instead store it directly within the map, e.g.
```cpp
    static inline Map<Thread::Id, Box<Thread_Profile>, Mhidden> threads;
```
but that also would require some other changes, so in this PR I implemented a simpler solution that only addresses crashing. 

The second example reveals another issue with destruction order, this time with the static data contained in `impl/log.cpp`. In this case when the lock on `this_thread.frames_lock` fails and an attempt is made to write an error message from `die`,
https://github.com/TheNumbat/rpp/blob/29ad6ef08d82658b4aefc46efcb2e5455d63f1c9/rpp/pos/thread_pos.cpp#L211-L215
the implementation of `output` tries to lock another mutex, `g_log_data.lock`, which is an object of static storage duration.
https://github.com/TheNumbat/rpp/blob/29ad6ef08d82658b4aefc46efcb2e5455d63f1c9/rpp/impl/log.cpp#L150
Because there is no set order of initialization or destruction of static variables between TUs, it is possible that the destructor of `g_log_data` will be called before the destructor of the global `Vec` object in the TU containing `main`, and that seems to have happened here. The stack trace shows that the attempt to lock `g_log_data.lock` fails, and `die` is called again to report the failure, resulting in recursion until an eventual segfault.

I made sure that `g_log_data` is constructed before its first use and destroyed after its last use by placing an inline variable in `log.h` which wraps the constructor and destructor of `Static_Data`. This guarantees that any static object appearing in a TU after the inclusion of `log.h` will be constructed after `g_log_data` and destroyed before it.
